### PR TITLE
[G.EXP.23-CPP] Fix warning_1857

### DIFF
--- a/libs/filabridge/src/SamplerInterfaceBlock.cpp
+++ b/libs/filabridge/src/SamplerInterfaceBlock.cpp
@@ -111,7 +111,7 @@ CString SamplerInterfaceBlock::generateUniformName(const char* group, const char
     char* const prefix = std::copy_n(group,
             std::min(sizeof(uniformName) / 2, strlen(group)), uniformName);
     if (uniformName[0] >= 'A' && uniformName[0] <= 'Z') {
-        uniformName[0] |= 0x20; // poor man's tolower()
+        uniformName[0] = static_cast<char>(std::tolower(static_cast<unsigned char>(uniformName[0])));
     }
     *prefix = '_';
 
@@ -123,6 +123,7 @@ CString SamplerInterfaceBlock::generateUniformName(const char* group, const char
 
     return CString{ uniformName, size_t(last - uniformName) - 1u };
 }
+
 
 SamplerInterfaceBlock::SamplerInfoList SamplerInterfaceBlock::filterSamplerList(
         SamplerInfoList list, backend::DescriptorSetLayout const& descriptorSetLayout) {


### PR DESCRIPTION
[G.EXP.23-CPP] The type of "uniformName[0]" is char. 
The operand "uniformName[0]" with signed type cannot be involved in the bit operation  of "uniformName[0] |= 32"