### PR TITLE
[G.EXP.25-CPP] Fix warning_465

### DIFF
--- a/filament/backend/test/ImageExpectations.cpp
+++ b/filament/backend/test/ImageExpectations.cpp
@@ -231,12 +231,13 @@ LoadedPng::LoadedPng(std::string filePath) : mFilePath(std::move(filePath)) {
     // The linear image is loaded with each component as [0.0, 1.0] but should be [0, 255], so
     // convert them.
     mBytes = std::vector<unsigned char>(valuesInImage);
-    for (int i = 0; i < valuesInImage; ++i) {
+    for (size_t i = 0; i < valuesInImage; ++i) {
         mBytes[i] = static_cast<uint8_t>(loadedImage.get<float>()[i] * 255.0f);
     }
 #endif
     // For platforms that don't support the image loading library, leave the loaded data blank.
 }
+
 
 uint32_t LoadedPng::hash() const {
     EXPECT_THAT(mBytes, testing::Not(testing::IsEmpty()))


### PR DESCRIPTION
[G.EXP.25-CPP] For the operator of '<' in expression 'i < valuesInImage', the type of left operand is signed, while the type of right operand is unsigned. Please do not mix signed and unsigned numbers